### PR TITLE
Fix animation when dismissOnTap with gravity

### DIFF
--- a/Classes/AFDropdownNotification.m
+++ b/Classes/AFDropdownNotification.m
@@ -209,6 +209,8 @@
         
         [UIView animateWithDuration:0.25 delay:0 options:UIViewAnimationOptionCurveEaseOut animations:^{
             
+            [_animator removeAllBehaviors];
+            
             _notificationView.frame = CGRectMake(0, -_notificationView.frame.size.height, [[UIScreen mainScreen] bounds].size.width, _notificationView.frame.size.height);
         } completion:^(BOOL finished) {
             


### PR DESCRIPTION
When dismissOnTap is ON and show a notification and before gravity behavior complete you tap to dismiss there is a misplacement of the notification view.
